### PR TITLE
fix for title NULL error

### DIFF
--- a/src/sources/FileSystem.php
+++ b/src/sources/FileSystem.php
@@ -218,7 +218,7 @@ class FileSystem extends ISource {
 
 		$sourceData = new ISourceFolders(
 			$this->sourceName,
-			$this->title,
+			$this->title ?? $this->sourceName,
 			$this->baseurl,
 			str_replace(realpath($this->getRoot()) . Consts::DS, '', $path),
 			[]


### PR DESCRIPTION
If you have sources defined and no title filled in, Jodit will give an error saying that the second parameter given to ISourceFolders is NULL instead of a string.  This results in folders on the left not being displayed

Since title is not explained in:
https://github.com/xdan/jodit-connectors
I think it is best to default to the sourceName that was already defined.