### PR TITLE
Fix saveSameFileNameStrategy addNumber to be Helper::makeSafe () compliant

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -337,7 +337,7 @@ abstract class Helper {
 				$i = 1;
 				do {
 					$newFileName =
-						$file->getBasename() . "($i)." . $file->getExtension();
+						$file->getBasename() . "$i." . $file->getExtension();
 					$i += 1;
 				} while (file_exists($file->getFolder() . $newFileName));
 


### PR DESCRIPTION
Fix saveSameFileNameStrategy addNumber to be Helper::makeSafe () compliant

Issue : https://github.com/xdan/jodit-connectors/issues/22