### PR TITLE
Fix PHP 8.4: implicitly marking parameter as nullable is deprecated

### DIFF
--- a/src/components/Config.php
+++ b/src/components/Config.php
@@ -236,7 +236,7 @@ class Config {
 	 * Get full path for $_REQUEST[$name] relative path with trailing slash(if directory)
 	 * @throws \Exception
 	 */
-	public function getPath(string $relativePath = null): string {
+	public function getPath(?string $relativePath = null): string {
 		$root = $this->getRoot();
 
 		if ($relativePath === null) {

--- a/src/interfaces/ISource.php
+++ b/src/interfaces/ISource.php
@@ -41,6 +41,6 @@ abstract class ISource extends Config {
 
 	abstract public function makeFile(
 		string $path,
-		string $content = null
+		?string $content = null
 	): IFile;
 }

--- a/src/sources/FileSystem.php
+++ b/src/sources/FileSystem.php
@@ -29,7 +29,7 @@ class FileSystem extends ISource {
 	 * @return IFile
 	 * @throws Exception
 	 */
-	public function makeFile(string $path, string $content = null): IFile {
+	public function makeFile(string $path, ?string $content = null): IFile {
 		if ($content !== null) {
 			file_put_contents($path, $content);
 		}


### PR DESCRIPTION
Hi,

Small changes to avoid warnings in PHP 8.4